### PR TITLE
ENH: Adding Numpy to Ubuntu 14.04 to run ITK tests requiring NumPy

### DIFF
--- a/Ubuntu14.04/setup.sh
+++ b/Ubuntu14.04/setup.sh
@@ -14,6 +14,7 @@ sudo apt-get install -y cmake \
   git \
   build-essential \
   python-dev \
+  python-numpy \
   ccache \
   clang \
   wget \


### PR DESCRIPTION
BridgeNumPy requires NumPy to pass its tests.